### PR TITLE
Node.jsのバージョンを15から24に変更

### DIFF
--- a/.github/workflows/build_demo.yml
+++ b/.github/workflows/build_demo.yml
@@ -6,19 +6,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ["15.x"]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: install dependencies
-        run: npm ci
-        env:
-          CI: true
+      - uses: volta-cli/action@v4
+      - run: npm install
       - name: build demo page
         run: npm run build:demo
         env:

--- a/.github/workflows/tests-on-pull-request.yml
+++ b/.github/workflows/tests-on-pull-request.yml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: volta-cli/action@v4
-        with:
-          node-version: '16' # バージョンが低すぎるので今後の修正でバージョンを上げる
       - run: npm install
       - name: Type check
         run: tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "typescript": "^4.3.5",
     "webpack": "^5.101.3",
     "webpack-cli": "^6.0.1"
+  },
+  "volta": {
+    "node": "24.7.0"
   }
 }


### PR DESCRIPTION
### 概要
- 開発当初はNode15で動かしていたようだが、out-of-dateになっているため、最新LTSであるNode24に変更します
- Node.jsのバージョンはvoltaを使って固定することにします