### PR TITLE
Fix main script location in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet.mouseposition.ts",
   "version": "0.1.4",
   "description": "A plugin for Leaflet. One of the modern alternatives of Leaflet.MousePosition plugin.",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "build": "rm -rf ./dist && tsc --declaration",
     "build:web": "webpack --config webpack.config.ts",


### PR DESCRIPTION
I was running into issues attempting to import this package in one of my projects that I'm working on, so I did some digging and found that this package was pointing to a main file that doesn't exist in the actual distributed package.

Poked around a little and found out where this file was actually located at, so adjusted the `package.json` file to point there and got it imported successfully!