### PR TITLE
Leaflet v2への対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ mousePosition.addTo(map);
 
 - position
   - You can choose which corner you want to display.
-- customElement(optional)
+- customComponent(optional)
   - You can custmize how this plugin looks by writting a React component.
   - For more details, look at [`demo/index.tsx`](./demo/index.tsx) .
 - clickToCopy(optional)
@@ -112,7 +112,7 @@ import {
 	MousePositionControlProps,
 } from "leaflet.mouseposition.ts";
 
-const customElement: React.FunctionComponent<MousePositionControlProps> = (
+const customComponent: React.FunctionComponent<MousePositionControlProps> = (
 	props
 ) => {
 	return (
@@ -131,7 +131,7 @@ const customElement: React.FunctionComponent<MousePositionControlProps> = (
 
 const mousePosition = new MousePosition({
 	position: "topright",
-	customElement: customElement,
+	customComponent: customComponent,
 });
 mousePosition.addTo(map);
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Leaflet.MousePosition.ts
 
 [![npm version](https://badge.fury.io/js/leaflet.mouseposition.ts.svg)](https://badge.fury.io/js/leaflet.mouseposition.ts)
+[![Leaflet 1.x](https://img.shields.io/badge/Leaflet-1.x-green)](https://leafletjs.com)
+[![Leaflet 2.0](https://img.shields.io/badge/Leaflet-2.0--alpha-blue)](https://leafletjs.com)
 
 Customizable coordinate viewer written in TypeScript
 
@@ -44,17 +46,36 @@ Demo page is [here](https://yuukitoriyama.github.io/leaflet-plugins/Leaflet.Mous
 </html>
 ```
 
+> **Note for CDN users**: As of v0.2.0, `L.MousePosition` global registration has been removed (see [Breaking Changes](#breaking-changes)). Please use the npm package instead.
+
 ### Basic Use
 
 First, please import a class `MousePosition`, then create an instance of this with giving some options.
 Adding it to the map, you can see new panel on your leaflet.
 
+#### Leaflet 2.0 (recommended)
+
 ```typescript
+import { Map as LeafletMap, TileLayer } from "leaflet";
 import { MousePosition } from "leaflet.mouseposition.ts";
 
-const mousePosition = new MousePosition({
-	position: "topright",
-});
+const map = new LeafletMap("myMap", { center: [35.0, 135.7], zoom: 13 });
+new TileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
+
+const mousePosition = new MousePosition({ position: "topright" });
+mousePosition.addTo(map);
+```
+
+#### Leaflet 1.x
+
+```typescript
+import L from "leaflet";
+import { MousePosition } from "leaflet.mouseposition.ts";
+
+const map = L.map("myMap", { center: [35.0, 135.7], zoom: 13 });
+L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
+
+const mousePosition = new MousePosition({ position: "topright" });
 mousePosition.addTo(map);
 ```
 
@@ -63,7 +84,7 @@ mousePosition.addTo(map);
 ```typescript
 {
 	position: 'topleft' | 'topright' | 'bottomleft' | 'bottomright',
-	customElement?: React.FunctionComponent<MousePositionControlProps>,
+	customComponent?: React.FunctionComponent<MousePositionControlProps>,
 	clickToCopy?: boolean
 }
 ```
@@ -114,6 +135,12 @@ const mousePosition = new MousePosition({
 });
 mousePosition.addTo(map);
 ```
+
+## Breaking Changes
+
+### v0.2.0
+
+- **`L.MousePosition` global registration removed**: The plugin no longer registers itself on the global `L` object. If you were using `new L.MousePosition()`, please migrate to the named import pattern shown above.
 
 ## Demo
 

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import 'leaflet/dist/leaflet.css';
-import L from 'leaflet';
+import { Map as LeafletMap, TileLayer } from 'leaflet';
 import { MousePosition, MousePositionControlProps } from '../src';
 import Header from './Header';
 
@@ -41,14 +41,14 @@ const customControl: React.FunctionComponent<MousePositionControlProps> = (props
 };
 const App: React.FunctionComponent = () => {
 	const mapRef = React.useRef<HTMLDivElement>(null);
-	let map: L.Map;
+	let map: LeafletMap;
 	let mousePositionControl: MousePosition;
 	React.useEffect(() => {
-		map = L.map(mapRef.current!, {
+		map = new LeafletMap(mapRef.current!, {
 			center: config.center,
 			zoom: config.zoom
 		});
-		L.tileLayer(config.basemap.tile, {
+		new TileLayer(config.basemap.tile, {
 			attribution: config.basemap.credit,
 			id: config.basemap.name,
 			detectRetina: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leaflet.mouseposition.ts",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "leaflet.mouseposition.ts",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "react": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@types/leaflet": "^1.9.6",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^17.0.14",
         "@types/react-dom": "^17.0.9",
         "css-loader": "^6.0.0",
         "html-webpack-plugin": "^5.3.2",
-        "leaflet": "^1.9.4",
+        "leaflet": "^2.0.0-alpha.1",
         "react-github-btn": "^1.2.0",
         "style-loader": "^3.1.0",
         "ts-loader": "^9.2.3",
@@ -26,6 +26,9 @@
         "typescript": "5.9.2",
         "webpack": "^5.101.3",
         "webpack-cli": "^6.0.1"
+      },
+      "peerDependencies": {
+        "leaflet": ">=1.7.1 || ^2.0.0-alpha"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -174,9 +177,9 @@
       "dev": true
     },
     "node_modules/@types/leaflet": {
-      "version": "1.9.20",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
-      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1352,9 +1355,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-2EJU27z/wljOgQCyybRkfrm5Xc3uy6huKehh0UAPsrAdwnSMxaplsqCl9cXPAuDm6D7uL6PCznYMDVIsaAdSdA==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
@@ -2535,9 +2538,9 @@
       "dev": true
     },
     "@types/leaflet": {
-      "version": "1.9.20",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
-      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"
@@ -3381,9 +3384,9 @@
       "dev": true
     },
     "leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-2EJU27z/wljOgQCyybRkfrm5Xc3uy6huKehh0UAPsrAdwnSMxaplsqCl9cXPAuDm6D7uL6PCznYMDVIsaAdSdA==",
       "dev": true
     },
     "loader-runner": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet.mouseposition.ts",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "A plugin for Leaflet. One of the modern alternatives of Leaflet.MousePosition plugin.",
   "main": "dist/src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
+  "peerDependencies": {
+    "leaflet": ">=1.7.1 || ^2.0.0-alpha"
+  },
   "devDependencies": {
-    "@types/leaflet": "^1.9.6",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
     "css-loader": "^6.0.0",
     "html-webpack-plugin": "^5.3.2",
-    "leaflet": "^1.9.4",
+    "leaflet": "^2.0.0-alpha.1",
     "react-github-btn": "^1.2.0",
     "style-loader": "^3.1.0",
     "ts-loader": "^9.2.3",

--- a/src/MousePosition.tsx
+++ b/src/MousePosition.tsx
@@ -55,6 +55,9 @@ export class MousePosition extends Control {
 		return this._div;
 	}
 	onRemove = () => {
-		console.log("Bye");
+		if (this._div) {
+			ReactDOM.unmountComponentAtNode(this._div);
+			this._div = null;
+		}
 	}
 }

--- a/src/MousePosition.tsx
+++ b/src/MousePosition.tsx
@@ -14,8 +14,10 @@ const ControlBase: React.FunctionComponent<{ map: Map, control: React.FunctionCo
 		const onClick = (event: LeafletEvent) => {
 			const { latlng } = event as LeafletMouseEvent;
 			setCoords(latlng);
-			props.clickToCopy && navigator.clipboard.writeText(latlng.toString()).then(() => {
+			props.clickToCopy && navigator.clipboard?.writeText(latlng.toString()).then(() => {
 				console.log("Copied to Clipboard");
+			}).catch((err) => {
+				console.warn("Failed to copy to clipboard", err);
 			});
 		};
 		props.map.on(moveEvent, onMouseMove);

--- a/src/MousePosition.tsx
+++ b/src/MousePosition.tsx
@@ -1,4 +1,4 @@
-import { Control, Map, LatLng, DomUtil, LeafletMouseEvent, ControlOptions } from 'leaflet';
+import { Control, Map, LatLng, DomUtil, LeafletEvent, LeafletMouseEvent, ControlOptions, version } from 'leaflet';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -6,17 +6,25 @@ import { MousePositionControl, MousePositionControlProps } from './Control';
 
 const ControlBase: React.FunctionComponent<{ map: Map, control: React.FunctionComponent<MousePositionControlProps>, clickToCopy: boolean }> = (props) => {
 	const [coords, setCoords] = React.useState(new LatLng(0, 0));
-	props.map.on({
-		mousemove: (event: LeafletMouseEvent) => {
-			setCoords(event.latlng);
-		},
-		click: (event: LeafletMouseEvent) => {
-			setCoords(event.latlng);
-			props.clickToCopy && navigator.clipboard.writeText(event.latlng.toString()).then(() => {
+	React.useEffect(() => {
+		const moveEvent = version.startsWith('1.') ? 'mousemove' : 'pointermove';
+		const onMouseMove = (event: LeafletEvent) => {
+			setCoords((event as LeafletMouseEvent).latlng);
+		};
+		const onClick = (event: LeafletEvent) => {
+			const { latlng } = event as LeafletMouseEvent;
+			setCoords(latlng);
+			props.clickToCopy && navigator.clipboard.writeText(latlng.toString()).then(() => {
 				console.log("Copied to Clipboard");
 			});
-		}
-	});
+		};
+		props.map.on(moveEvent, onMouseMove);
+		props.map.on('click', onClick);
+		return () => {
+			props.map.off(moveEvent, onMouseMove);
+			props.map.off('click', onClick);
+		};
+	}, [props.map, props.clickToCopy]);
 	return (
 		<props.control latlng={coords} />
 	)

--- a/src/MousePosition.tsx
+++ b/src/MousePosition.tsx
@@ -1,10 +1,4 @@
-import L, {
-    Map,
-    LatLng,
-    DomUtil,
-    LeafletMouseEvent,
-    ControlOptions,
-} from 'leaflet';
+import { Control, Map, LatLng, DomUtil, LeafletMouseEvent, ControlOptions } from 'leaflet';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -33,7 +27,7 @@ export interface MousePositionProps extends ControlOptions {
 	clickToCopy?: boolean
 }
 
-export class MousePosition extends L.Control {
+export class MousePosition extends Control {
 	_div: HTMLElement | null;
 	control: React.FunctionComponent<MousePositionControlProps>;
 	clickToCopy: boolean
@@ -56,5 +50,3 @@ export class MousePosition extends L.Control {
 		console.log("Bye");
 	}
 }
-
-(L as any).MousePosition = MousePosition;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "sourceMap": true,
-        "baseUrl": "./",
         "target": "ESNEXT",
         "strict": true,
         "outDir": "./dist",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 使用例をLeaflet 2.0および1.x形式に対応した形に更新
  * CDN利用者向けの注意事項を追加

* **Chores**
  * バージョン0.2.0にリリース
  * Leaflet依存関係を更新（>=1.7.1 || ^2.0.0-alpha互換）
  * プロパティ名を`customElement`から`customComponent`に変更

* **Breaking Changes**
  * グローバル登録機能の削除

<!-- end of auto-generated comment: release notes by coderabbit.ai -->